### PR TITLE
Add FastAPI prototype for legal DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # Saniia
+
+This repository contains various experimentation notebooks and a prototype
+application. See the `legal_db/` directory for a minimal FastAPI service that
+illustrates how a Madagascar legal document API might be structured.

--- a/legal_db/README.md
+++ b/legal_db/README.md
@@ -1,0 +1,23 @@
+# Madagascar Legal Database Prototype
+
+This directory contains a minimal FastAPI application that serves as a starting
+point for a legal document search tool for Madagascar's laws. The application
+exposes endpoints to list available laws and retrieve a single law by ID. At the
+moment, it uses an in-memory list of laws as a placeholder.
+
+## Quickstart
+
+1. Install dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Run the application:
+
+   ```bash
+   uvicorn app:app --reload
+   ```
+
+The API will be available at `http://localhost:8000` and you can browse the
+interactive documentation at `/docs`.

--- a/legal_db/app.py
+++ b/legal_db/app.py
@@ -1,0 +1,27 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+from typing import List
+
+app = FastAPI(title="Madagascar Legal DB")
+
+class Law(BaseModel):
+    id: int
+    title: str
+    content: str
+
+# In-memory store as placeholder
+laws_db: List[Law] = [
+    Law(id=1, title="Sample Law", content="Full text of law"),
+]
+
+@app.get("/laws", response_model=List[Law])
+def list_laws():
+    """Return available laws"""
+    return laws_db
+
+@app.get("/laws/{law_id}", response_model=Law)
+def get_law(law_id: int):
+    for law in laws_db:
+        if law.id == law_id:
+            return law
+    return {"error": "Law not found"}

--- a/legal_db/requirements.txt
+++ b/legal_db/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+pydantic


### PR DESCRIPTION
## Summary
- document repo structure in README
- add FastAPI prototype under `legal_db/`
- include a requirements file and instructions for running

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6854f26159f48331a5a9fc2e11ce4319